### PR TITLE
should gracefully  fail if required commands are not found

### DIFF
--- a/src/Umpirsky/PermissionsHandler/ScriptHandler.php
+++ b/src/Umpirsky/PermissionsHandler/ScriptHandler.php
@@ -10,10 +10,10 @@ class ScriptHandler
     public static function setPermissions(CommandEvent $event)
     {
         if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
-            $event->getIO()->write('No permissions setup is required on Windows.');
+            $event->getIO()->write('<info>No permissions setup is required on Windows.</info>');
             return;
         }
-        
+
         $event->getIO()->write('Setting up permissions.');
 
         try {
@@ -21,6 +21,8 @@ class ScriptHandler
 
             return;
         } catch (ProcessFailedException $setfaclException) {
+            $event->getIO()->write(sprintf('<error>%s</error>', $setfaclException->getMessage()));
+            $event->getIO()->write('<info>Trying chmod...</info>');
         }
 
         try {
@@ -28,9 +30,8 @@ class ScriptHandler
 
             return;
         } catch (ProcessFailedException $chmodException) {
+            $event->getIO()->write(sprintf('<error>%s</error>', $chmodException->getMessage()));
         }
-
-        throw $setfaclException;
     }
 
     public static function setPermissionsSetfacl(CommandEvent $event)


### PR DESCRIPTION
Travis seems to be missing the setfacl command, so running `composer install` fails

Here is the build output:

```
Script Umpirsky\PermissionsHandler\ScriptHandler::setPermissions handling the post-install-cmd event terminated with an exception

[Symfony\Component\Process\Exception\ProcessFailedException]

The command "setfacl -R -m u:"":rwX -m u:`whoami`:rwX var/cache" failed.

Exit Code: 127(Command not found)

Output:

================

Error Output:

================

sh: 1: setfacl: not found 
``


```
