### PR TITLE
Fixed "setfacl: Operation not permitted" error on Linux

### DIFF
--- a/src/Umpirsky/PermissionsHandler/SetfaclPermissionsSetter.php
+++ b/src/Umpirsky/PermissionsHandler/SetfaclPermissionsSetter.php
@@ -12,7 +12,7 @@ class SetfaclPermissionsSetter extends PermissionsSetter
             throw new PathNotFoundException($path);
         }
 
-        $this->runCommand('setfacl -R -m u:"%httpduser%":rwX -m u:`whoami`:rwX %path%', $path);
-        $this->runCommand('setfacl -dR -m u:"%httpduser%":rwX -m u:`whoami`:rwX %path%', $path);
+        $this->runCommand('setfacl -m u:"%httpduser%":rwX -m u:`whoami`:rwX %path%', $path);
+        $this->runCommand('setfacl -d -m u:"%httpduser%":rwX -m u:`whoami`:rwX %path%', $path);
     }
 }


### PR DESCRIPTION
When I have files created by the web server, the permission setup fails.

```
The command "setfacl -R -m u:"www-data":rwX -m u:`whoami`:rwX app/logs" failed.
Exit Code: 1(General error)

Output:
================


Error Output:
================
setfacl: app/logs/dev.log: Operation not permitted
```

I fixed the error by removing the -R flag. Recursive ACL is already done by the -d flag, which sets the default ACL for new files.